### PR TITLE
Fixed windows and linux(gcc) installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,7 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 recursive-include src *.pyx
 
+graft src/TotalDepth/LIS/core/src/cp
+graft src/TotalDepth/LIS/core/src/cpp
+
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,10 @@ XML_FORMAT_FILES = [os.path.join(*p.split('/')) for p in XML_FORMAT_FILES]
 #     module_list="src/TotalDepth/LIS/core/*.pyx",
 # )
 
-extra_compile_args = sysconfig.get_config_var('CFLAGS').split()
+extra_compile_args = []
+cflags = sysconfig.get_config_var('CFLAGS')
+if cflags != None:
+    extra_compile_args = sysconfig.get_config_var('CFLAGS').split()
 
 ext_modules = [
     Extension(


### PR DESCRIPTION
Hi,

Here is the issues I found when it comes to installing on Windows 10 and Linux Ubuntu.

Windows is related to CFLAGS missing
Linux is related to missing header files for gcc