### PR TITLE
Fixed issue with deprecated time.clock() in python>=3.3

### DIFF
--- a/src/TotalDepth/LAS/ReadLASFiles.py
+++ b/src/TotalDepth/LAS/ReadLASFiles.py
@@ -82,7 +82,10 @@ class ReadLASFiles(object):
     def _processFile(self, fp):
         """Process a single file. Returns the size of the file and the time taken to process."""
         rSize = os.path.getsize(fp)
-        clkStart = time.clock()
+        if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+            clkStart = time.perf_counter()
+        else:
+            clkStart = time.clock()
         try:
             myLr = LASRead.LASRead(fp)
             self._cntrs['byte'] += rSize
@@ -98,7 +101,10 @@ class ReadLASFiles(object):
             logging.critical(traceback.format_exc())
             self._cntrs['crit'] += 1
         self._cntrs['file'] += 1
-        return rSize, time.clock() - clkStart 
+        if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+            return rSize, time.perf_counter() - clkStart 
+        else:
+            return rSize, time.clock() - clkStart 
     
     def _procLAS(self, las):
         self._updateDescMaps(las)
@@ -273,7 +279,10 @@ Recursively reads LAS files in a directory reporting information about their con
             help="Log Level (debug=10, info=20, warning=30, error=40, critical=50) [default: %default]"
         )      
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     timStart = time.time()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
@@ -293,7 +302,10 @@ Recursively reads LAS files in a directory reporting information about their con
     myReader.pprintWsd()
     # myReader.pprintSizeTime()
     print(myReader.results())
-    print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        print('  CPU time = %8.3f (S)' % (time.perf_counter() - clkStart))
+    else:
+        print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
     print('Exec. time = %8.3f (S)' % (time.time() - timStart))
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/DumpFrameSet.py
+++ b/src/TotalDepth/LIS/DumpFrameSet.py
@@ -132,7 +132,10 @@ Reads a LIS file and writes out tab separated values of each frame."""
     optParser.add_option("-c", "--channels", action="append", type="str",
                          help="Only dump these named curves.", default=[])
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -144,7 +147,10 @@ Reads a LIS file and writes out tab separated values of each frame."""
         optParser.error("I can't do much without a path to the LIS file.")
         return 1
     dumpFrameSets(args[0], opts.keepGoing, opts.summary, set([v.encode('ascii') for v in opts.channels]))
-    clkExec = time.clock() - clkStart
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/Index.py
+++ b/src/TotalDepth/LIS/Index.py
@@ -142,14 +142,20 @@ def indexFile(fp, numTimes, verbose, keepGoing, convertJson):
         myLenJson = -1
         timeS = []
         for t in range(numTimes):
-            clkStart = time.clock()
+            if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+                clkStart = time.perf_counter()
+            else:
+                clkStart = time.clock()
             myFi = File.FileRead(fp, theFileId=fp, keepGoing=keepGoing)
             try:
                 myIdx = FileIndexer.FileIndex(myFi)
             except ExceptionTotalDepthLIS as err:
                 logging.error('{:s}'.format(str(err)))
                 continue
-            timeS.append(time.clock() - clkStart)
+            if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+                timeS.append(time.perf_counter() - clkStart)
+            else:
+                timeS.append(time.clock() - clkStart)
             if verbose:
                 print(myIdx.longDesc())
                 print(' All records '.center(75, '='))
@@ -306,7 +312,10 @@ Indexes LIS files recursively."""
                     stream=sys.stdout)
     # Your code here
     #print('opts', opts)
-    clkStart = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     myIt = IndexTimer()
     if len(args) != 1:
         optParser.print_help()
@@ -332,7 +341,11 @@ Indexes LIS files recursively."""
         print('Results: {:8d}'.format(len(myIt)))
         print(' Errors: {:8d}'.format(myIt.errCount))
         print('  Total: {:8d}'.format(len(myIt)+myIt.errCount))
-    clkExec = time.clock() - clkStart
+
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/PlotLogPasses.py
+++ b/src/TotalDepth/LIS/PlotLogPasses.py
@@ -614,7 +614,10 @@ Generates plot(s) from input LIS file or directory to an output destination."""
     optParser.add_option("-x", "--xml", action="append", dest="LgFormat", default=[],
                       help="Add an XML LgFormat to use for plotting. Value is the UniqueId. Use -x? to see what LgFormats are available. [default: %default]")
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     timStart = time.time()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
@@ -641,7 +644,10 @@ Generates plot(s) from input LIS file or directory to an output destination."""
         myResult = plotLogPassesMP(args[0], args[1], None, opts.recursive, opts.keepGoing, opts.LgFormat, opts.apiHeader, opts.jobs)
     myResult.writeHTML(os.path.join(args[1], 'index.html'), args[0])
     print('plotLogInfo', str(myResult))
-    print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        print('  CPU time = %8.3f (S)' % (time.perf_counter() - clkStart))
+    else:
+        print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
     print('Exec. time = %8.3f (S)' % (time.time() - timStart))
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/RandomFrameSetRead.py
+++ b/src/TotalDepth/LIS/RandomFrameSetRead.py
@@ -116,14 +116,27 @@ class ResultS(object):
         return 'NO results.'
 
 def _loadFrameSetAndAccumulate(theF, theLp, theFrameSlice, theChList):
-    tS = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        tS = time.perf_counter()
+    else:
+        tS = time.clock()
     theLp.setFrameSet(theF, theFrSl=theFrameSlice, theChList=theChList)
-    tE_load = time.clock() - tS
-    tS = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        tE_load = time.perf_counter() - tS
+    else:
+        tE_load = time.clock() - tS
+
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        tS = time.perf_counter()
+    else:
+        tS = time.clock()
     #print('theFrameSlice', theFrameSlice)
     myAcc = theLp.frameSet.accumulate([FrameSet.AccMin, FrameSet.AccMax, FrameSet.AccMean,])
     #print(myAcc)
-    tE_acc = time.clock() - tS
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        tE_acc = time.perf_counter() - tS
+    else:
+        tE_acc = time.clock() - tS
     numVals = theLp.frameSet.numValues
     mbRead = numVals * 4 / 2**20
     loadCost = 1000 * tE_load / mbRead
@@ -293,10 +306,16 @@ def processFile(f, tests, keepGoing, resultMap):
         myFi = File.FileRead(f, theFileId=f, keepGoing=keepGoing)
         #a = r'W:\LISTestData\logPassStd256MB.lis'
         #myFi = File.FileRead(a, theFileId=a)
-        clkStart = time.clock()
+        if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+            clkStart = time.perf_counter()
+        else:
+            clkStart = time.clock()
         myIdx = FileIndexer.FileIndex(myFi)
         #print(myIdx.longDesc())
-        print('Index time: {:.3f}'.format(time.clock() - clkStart))
+        if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+            print('Index time: {:.3f}'.format(time.perf_counter() - clkStart))
+        else:
+            print('Index time: {:.3f}'.format(time.clock() - clkStart))
     except Exception as err:
         logging.error(str(err))
         traceback.print_exc()
@@ -372,7 +391,10 @@ E - Random frames, random channels.
     opts, args = optParser.parse_args()
     global LOOPS_TO_TEST
     LOOPS_TO_TEST = opts.numTests
-    clkStart = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -400,7 +422,10 @@ E - Random frames, random channels.
         optParser.print_help()
         optParser.error("Wrong number of arguments, I need one only.")
         return 1
-    clkExec = time.clock() - clkStart
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/ScanLogiData.py
+++ b/src/TotalDepth/LIS/ScanLogiData.py
@@ -127,7 +127,10 @@ Scans a LIS79 file and dumps logical record data."""
     optParser.add_option("-v", "--verbose", action="store_true", dest="verbose", default=False, 
                       help="Verbose Output. [default: %default]")
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -140,7 +143,10 @@ Scans a LIS79 file and dumps logical record data."""
         optParser.print_help()
         optParser.error("Wrong number of arguments, I need one only.")
         return 1
-    clkExec = time.clock() - clkStart
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/ScanLogiRec.py
+++ b/src/TotalDepth/LIS/ScanLogiRec.py
@@ -119,7 +119,10 @@ Scans a LIS79 file and dumps Logical Records."""
     optParser.add_option("-v", "--verbose", action="store_true", dest="verbose", default=False, 
                       help="Verbose Output. [default: %default]")
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -132,7 +135,11 @@ Scans a LIS79 file and dumps Logical Records."""
         optParser.print_help()
         optParser.error("Wrong number of arguments, I need one only.")
         return 1
-    clkExec = time.clock() - clkStart
+
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/ScanPhysRec.py
+++ b/src/TotalDepth/LIS/ScanPhysRec.py
@@ -107,7 +107,10 @@ Scans a LIS79 file and reports Physical Record structure."""
             help="Log Level (debug=10, info=20, warning=30, error=40, critical=50) [default: %default]"
         )      
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -120,7 +123,10 @@ Scans a LIS79 file and reports Physical Record structure."""
         optParser.print_help()
         optParser.error("Wrong number of arguments, I need one only.")
         return 1
-    clkExec = time.clock() - clkStart
+    if ((sys.version_info.major >= 3) and (sys.version_info.minor >= 3)):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/TableHistogram.py
+++ b/src/TotalDepth/LIS/TableHistogram.py
@@ -216,7 +216,10 @@ Provides a count of elements in LIS tables."""
             help="Log Level (debug=10, info=20, warning=30, error=40, critical=50) [default: %default]"
         )      
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -246,7 +249,10 @@ Provides a count of elements in LIS tables."""
         pprint.pprint(myCntr.cntrColMnem)
         print(' Column entries END '.center(75, '='))
         print()
-    clkExec = time.clock() - clkStart
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/LIS/core/GenLisFiles.py
+++ b/src/TotalDepth/LIS/core/GenLisFiles.py
@@ -293,7 +293,10 @@ Counts files and sizes."""
                          default='', 
                          help="Output directory. [default: %default]")
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -304,7 +307,10 @@ Counts files and sizes."""
         os.makedirs(opts.outdir)
     myGlf = GenLisFiles(opts.outdir)
     print(myGlf)
-    clkExec = time.clock() - clkStart
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkExec = time.perf_counter() - clkStart
+    else:
+        clkExec = time.clock() - clkStart
     print('CPU time = %8.3f (S)' % clkExec)
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/PlotLogs.py
+++ b/src/TotalDepth/PlotLogs.py
@@ -735,7 +735,10 @@ def main():
     cmn_cmd_opts.set_log_level(args)
     # print('args', args)
     # return 0
-    start_clock = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        start_clock = time.perf_counter()
+    else:
+        start_clock = time.clock()
     start_time = time.time()
     # Your code here
     if '?' in ''.join(args.LgFormat):
@@ -760,7 +763,10 @@ def main():
     if os.path.isdir(args.path_out):
         myResult.writeHTML(os.path.join(args.path_out, 'index.html'), args.path_in)
     print('plotLogInfo', str(myResult))
-    print('  CPU time = %8.3f (S)' % (time.clock() - start_clock))
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        print('  CPU time = %8.3f (S)' % (time.perf_counter() - start_clock))
+    else:
+        print('  CPU time = %8.3f (S)' % (time.clock() - start_clock))
     print('Exec. time = %8.3f (S)' % (time.time() - start_time))
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/util/PatternSearch.py
+++ b/src/TotalDepth/util/PatternSearch.py
@@ -221,7 +221,10 @@ def main():
     op.add_argument('infile', type=argparse.FileType('rb'), help='The file to search')
     args = op.parse_args()
 #    print('TRACE: args', args)
-    clkStart = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     timStart = time.time()
     # Initialise logging etc.
     logging.basicConfig(level=args.loglevel,
@@ -239,7 +242,10 @@ def main():
 #    reportIDENT(args.infile, theMin=args.min_run_length, showTell=args.show_tell)
 #    reportSLB(args.infile, showTell=args.show_tell)
     reportTOOL(args.infile, showTell=args.show_tell)
-    print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        print('  CPU time = %8.3f (S)' % (time.perf_counter() - clkStart))
+    else:
+        print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
     print('Exec. time = %8.3f (S)' % (time.time() - timStart))
     print('Bye, bye!')
     return 0

--- a/src/TotalDepth/util/plot/AREACfg.py
+++ b/src/TotalDepth/util/plot/AREACfg.py
@@ -371,7 +371,10 @@ Counts files and sizes."""
             help="Log Level (debug=10, info=20, warning=30, error=40, critical=50) [default: %default]"
         )      
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
                     format='%(asctime)s %(levelname)-8s %(message)s',

--- a/src/TotalDepth/util/plot/ViewSVGHeader.py
+++ b/src/TotalDepth/util/plot/ViewSVGHeader.py
@@ -172,7 +172,10 @@ Generates plot(s) from input LIS file or directory to and output destination."""
             help="Log Level (debug=10, info=20, warning=30, error=40, critical=50) [default: %default]"
         )      
     opts, args = optParser.parse_args()
-    clkStart = time.clock()
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        clkStart = time.perf_counter()
+    else:
+        clkStart = time.clock()
     timStart = time.time()
     # Initialise logging etc.
     logging.basicConfig(level=opts.loglevel,
@@ -184,7 +187,10 @@ Generates plot(s) from input LIS file or directory to and output destination."""
         optParser.print_help()
         return 1
     myObj = ViewSVG(args[0])
-    print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
+    if (sys.version_info.major >= 3 and sys.version_info.minor >= 3):
+        print('  CPU time = %8.3f (S)' % (time.perf_counter() - clkStart))
+    else:
+        print('  CPU time = %8.3f (S)' % (time.clock() - clkStart))
     print('Exec. time = %8.3f (S)' % (time.time() - timStart))
     print('Bye, bye!')
     return 0


### PR DESCRIPTION
This submission fix issues with deprecated method `time.clock()` that was removed in python 3.8 but also keeps retro compatibility checking for python version and calling right method. Since these functions are not called inside cpu bound tight loops the additional branching do not cause overheads.